### PR TITLE
Selectively Lint Large Workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The Chef Infra Extension for Visual Studio Code offers rich language support for
 #### Cookstyle linting and source analysis:
 
  * Enabled by default (disable by adding ```{ "rubocop.enable": false }``` in user/workspace settings) and activated when the first Ruby file is loaded.
- * The entire repo will be linted when files are saved.
+ * The entire repo will be linted when files are saved, unless there are more than 400 `*.rb` files in the workspace, in which case only open files will be linted. Adjust this threshold using the ```{ "rubocop.fileCountThreshold": 400 }``` setting in user/workspace settings.
+ * You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Pallette.
  * If you have [Chef Workstation](https://downloads.chef.io/chef-workstation) installed, linting should "just work" on Windows, macOS and Linux. [Cookstyle](https://github.com/chef/cookstyle) will be used by default.
  * If you do not have Chef Workstation but do have Rubocop installed, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\rubocop.bat"}``` in user/workspace settings).
  * To override the config file used by Rubocop/Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings.

--- a/extension.ts
+++ b/extension.ts
@@ -85,8 +85,8 @@ function validate(warn:boolean = false): void {
 	} else {
 		if (warn) {
 			let msg: string = "There are a large number of Ruby files in your workspace. " +
-												"The Chef Infra Extension will only lint open files rather than " +
-												"the entire workspace to avoid becoming unresponsive."
+				"The Chef Infra Extension will only lint open files rather than " +
+				"the entire workspace to avoid becoming unresponsive."
 			vscode.window.showWarningMessage(msg,"Ok");
 		}
 		validateOpenFiles();

--- a/package.json
+++ b/package.json
@@ -124,6 +124,11 @@
           "type": "string",
           "default": "",
           "description": "Path to a Rubocop config file (e.g. .rubocop_shared.yml) - relative paths resolve inside the workspace."
+        },
+        "rubocop.fileCountThreshold": {
+          "type": "number",
+          "default": 400,
+          "description": "If there are are fewer than this many Ruby files, the extension will validate all files in the workspace. If greater, it will only validate the open files to keep the extension responsive."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,13 @@
           "description": "Path to a Rubocop config file (e.g. .rubocop_shared.yml) - relative paths resolve inside the workspace."
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "chef.validateEntireWorkspace",
+        "title": "Chef: Validate Workspace"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fs": "0.0.1-security",
     "path": "0.12.7",
     "tslint": "6.1.2",
-    "typescript": "2.3.4",
+    "typescript": "3.9.5",
     "vscode": "^1.1.14"
   },
   "extensionDependencies": [


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

If a workspace is "large", containing many Ruby files, the Rubocop process spawn will take several seconds to run. VSCode helpfully reports this as"Extension causes high CPU load" and offers to help the user open an issue, complete with CPU profile.

To avoid this, this PR detects at activation time how many `*.rb` files there are in the workspace. If there are more than 400 (my 2015 macbook pro would not tolerate 500), a warning message is briefly displayed, and the extension instead will lint all open Ruby editors that have filenames; presumably this would reflect the recipes you are actively working on.

The number of files at which to disable whole-workspace linting is adjustable via the setting `rubocop.fileCountThreshold`.

If a user still wishes to lint their entire workspace, they may now do so using the `Chef: Validate Entire Workspace` command on the Command Palette. There is no preventing a possible CPU usage warning, however.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Fixes #33 
Fixes #72
May make it safe to merge #76 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
