### PR TITLE
Add initial support for Berkshelf and Policyfiles snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "language"
   ],
   "activationEvents": [
-    "onLanguage:chef_metadata",
+    "onLanguage:chef_berkshelf",
     "onLanguage:chef_inspec",
+    "onLanguage:chef_metadata",
+    "onLanguage:chef_policyfile",
     "onLanguage:chef_recipe_yaml",
     "workspaceContains:**/metadata.rb"
   ],
@@ -59,8 +61,6 @@
           "Ruby"
         ],
         "extensions": [
-          "Berksfile",
-          "Policyfile",
           ".rb"
         ]
       },
@@ -98,7 +98,29 @@
           "**/recipes/*.yaml"
         ],
         "configuration": "./syntaxes/language_configuration_chef_yaml.json"
-      }
+      },
+			{
+				"id": "chef_policyfile",
+				"aliases": [
+					"Chef Infra Policyfile",
+					"chef Infra policyfile"
+				],
+				"configuration": "./syntaxes/language_configuration_chef_ruby.json",
+				"extensions": [
+					"Policyfile.rb"
+				]
+			},
+      {
+				"id": "chef_berksfile",
+				"aliases": [
+					"Chef Infra Berksfile",
+					"chef Infra berksfile"
+				],
+				"configuration": "./syntaxes/language_configuration_chef_ruby.json",
+				"extensions": [
+					"Berksfile"
+				]
+			}
     ],
     "grammars": [
       {
@@ -110,6 +132,16 @@
         "language": "chef_inspec",
         "scopeName": "source.ruby.chef_inspec",
         "path": "./syntaxes/chef_inspec.cson.json"
+      },
+      {
+        "language": "chef_berkshelf",
+        "scopeName": "source.chef.berkshelf",
+        "path": "./syntaxes/chef_berkshelf.cson.json"
+      },
+      {
+        "language": "chef_policyfile",
+        "scopeName": "source.chef.policyfile",
+        "path": "./syntaxes/chef_policyfile.cson.json"
       },
       {
         "language": "chef_metadata",
@@ -126,6 +158,14 @@
       {
         "language": "ruby",
         "path": "./snippets/chef_resources.json"
+      },
+      {
+        "language": "chef_berksfile",
+        "path": "./snippets/chef_berksfile.json"
+      },
+      {
+        "language": "chef_policyfile",
+        "path": "./snippets/chef_berksfile.json"
       },
       {
         "language": "chef_inspec",

--- a/package.json
+++ b/package.json
@@ -99,28 +99,28 @@
         ],
         "configuration": "./syntaxes/language_configuration_chef_yaml.json"
       },
-			{
-				"id": "chef_policyfile",
-				"aliases": [
-					"Chef Infra Policyfile",
-					"chef Infra policyfile"
-				],
-				"configuration": "./syntaxes/language_configuration_chef_ruby.json",
-				"extensions": [
-					"Policyfile.rb"
-				]
-			},
       {
-				"id": "chef_berksfile",
-				"aliases": [
-					"Chef Infra Berksfile",
-					"chef Infra berksfile"
-				],
-				"configuration": "./syntaxes/language_configuration_chef_ruby.json",
-				"extensions": [
-					"Berksfile"
-				]
-			}
+        "id": "chef_policyfile",
+        "aliases": [
+          "Chef Infra Policyfile",
+          "chef Infra policyfile"
+        ],
+        "configuration": "./syntaxes/language_configuration_chef_ruby.json",
+        "extensions": [
+          "Policyfile.rb"
+        ]
+      },
+      {
+        "id": "chef_berksfile",
+        "aliases": [
+          "Chef Infra Berksfile",
+          "chef Infra berksfile"
+        ],
+        "configuration": "./syntaxes/language_configuration_chef_ruby.json",
+        "extensions": [
+          "Berksfile"
+        ]
+      }
     ],
     "grammars": [
       {

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
       },
       {
         "language": "chef_policyfile",
-        "path": "./snippets/chef_berksfile.json"
+        "path": "./snippets/chef_policyfile.json"
       },
       {
         "language": "chef_inspec",

--- a/snippets/chef_berksfile.json
+++ b/snippets/chef_berksfile.json
@@ -1,0 +1,14 @@
+{
+	"source": {
+		"prefix": "source",
+		"scope": "source.chef.berksfile",
+		"body": "source '${1:https://supermarket.chef.io}'",
+		"description": "A source defines where Berkshelf should look for cookbooks. Sources are processed in the order that they are defined in, and processing stops as soon as a suitable cookbook is found."
+	},
+	"metadata": {
+		"prefix": "metadata",
+		"scope": "source.chef.berksfile",
+		"body": "metadata",
+		"description": "The metadata keyword causes Berkshelf to process the local cookbook metadata. This ensures that the dependencies of the cookbook are resolved by Berkshelf."
+	}
+}

--- a/snippets/chef_policyfile.json
+++ b/snippets/chef_policyfile.json
@@ -1,8 +1,8 @@
 {
-	"source": {
+	"default_source": {
 		"prefix": "default_source",
 		"scope": "source.chef.policyfile",
-		"body": "source '${1::supermarket}'",
+		"body": "default_source ${1::supermarket}",
 		"description": "The location in which any cookbooks not specified by cookbook are located."
 	},
 	"name": {

--- a/snippets/chef_policyfile.json
+++ b/snippets/chef_policyfile.json
@@ -1,0 +1,14 @@
+{
+	"source": {
+		"prefix": "default_source",
+		"scope": "source.chef.policyfile",
+		"body": "source '${1::supermarket}'",
+		"description": "The location in which any cookbooks not specified by cookbook are located."
+	},
+	"name": {
+		"prefix": "name",
+		"scope": "source.chef.policyfile",
+		"body": "name '${1::my_cookbook}'",
+		"description": "The name of the policy. Use a name that reflects the purpose of the machines against which the policy will run."
+	}
+}

--- a/syntaxes/chef_berkshelf.cson.json
+++ b/syntaxes/chef_berkshelf.cson.json
@@ -1,0 +1,10 @@
+{
+	"name": "Chef Infra Berksfile",
+	"scopeName": "source.chef.berksfile",
+	"fileTypes": ["Berksfile"],
+	"patterns": [
+		{
+			"include": "source.ruby"
+		}
+	]
+}

--- a/syntaxes/chef_metadata.cson.json
+++ b/syntaxes/chef_metadata.cson.json
@@ -1,5 +1,5 @@
 {
-	"name": "Chef Metadata",
+	"name": "Chef Infra Metadata",
 	"scopeName": "source.chef.metadata",
 	"fileTypes": ["metadata.rb"],
 	"patterns": [

--- a/syntaxes/chef_policyfile.cson.json
+++ b/syntaxes/chef_policyfile.cson.json
@@ -1,0 +1,10 @@
+{
+	"name": "Chef Infra Policyfile",
+	"scopeName": "source.chef.policyfile",
+	"fileTypes": ["Policyfile.rb"],
+	"patterns": [
+		{
+			"include": "source.ruby"
+		}
+	]
+}


### PR DESCRIPTION
Start by detecting these as languages with grammars and small snippets.

Signed-off-by: Tim Smith <tsmith@chef.io>