### PR TITLE
Update default Cookstyle paths for bin vs embedded

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -17,9 +17,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
 	if (vscode.workspace.getConfiguration("rubocop").path === "") {
 		if (process.platform === "win32") {
-			rubocopPath = "C:\\opscode\\chef-workstation\\embedded\\bin\\cookstyle.bat";
+			rubocopPath = "C:\\opscode\\chef-workstation\\bin\\cookstyle.bat";
 		} else {
-			rubocopPath = "/opt/chef-workstation/embedded/bin/cookstyle";
+			rubocopPath = "/opt/chef-workstation/bin/cookstyle";
 		}
 	} else {
 		rubocopPath = vscode.workspace.getConfiguration("rubocop").path;

--- a/snippets/chef_inspec_resources.json
+++ b/snippets/chef_inspec_resources.json
@@ -2585,6 +2585,12 @@
     "description": "Use the `mongodb_conf` Chef InSpec audit resource to test the contents of the configuration file for MongoDB, typically located at `/etc/mongod.conf` or `C:\\Program Files\\MongoDB\\Server\\<version>\\bin\\mongod.cfg`, depending on the platform.",
     "scope": "source.ruby.chef_inspec"
   },
+  "mongodb_session": {
+    "prefix": "mongodb_session",
+    "body": "describe mongodb_session(user: \"username\", password: \"password\", database: \"test\").query(key: value) do\n    its(\"params\") { should match(/expected-result/) }\n  end",
+    "description": "Use the `mongodb_session` Chef InSpec audit resource to run MongoDB command against a MongoDB Database.",
+    "scope": "source.ruby.chef_inspec"
+  },
   "mount": {
     "prefix": "mount",
     "body": "describe mount('path') do\n\tit { should MATCHER 'value' }\nend",
@@ -2637,6 +2643,18 @@
     "prefix": "oneget",
     "body": "describe oneget('name') do\n\tit { should be_installed }\nend",
     "description": "Use the `oneget` Chef InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses Oneget, which is `part of the Windows Management Framework 5.0 and Windows 10 <https://github.com/OneGet/oneget>`\\_\\_. This resource uses the `Get-Package` cmdlet to return all of the package names in the Oneget repository.",
+    "scope": "source.ruby.chef_inspec"
+  },
+  "opa_api": {
+    "prefix": "opa_api",
+    "body": "describe opa_api(url: \"localhost:8181/v1/data/example/violation\", data: \"input.json\") do\n\tits([\"result\"]) { should eq 'value' }\nend",
+    "description": "Use the `opa_api` Chef InSpec audit resource to query Open Policy Agent (OPA) using the OPA URL and data.",
+    "scope": "source.ruby.chef_inspec"
+  },
+  "opa_cli": {
+    "prefix": "opa_cli",
+    "body": "describe opa_cli(policy: \"example.rego\", data: \"input.json\", query: \"data.example.allow\") do\n\tits([\"result\"]) { should eq \"value\" }\nend",
+    "description": "Use the `opa_cli` Chef InSpec audit resource to query Open Policy Agent (OPA) using an OPA policy file, a data file, and a query.",
     "scope": "source.ruby.chef_inspec"
   },
   "oracledb_session": {

--- a/snippets/chef_inspec_resources.json
+++ b/snippets/chef_inspec_resources.json
@@ -2585,12 +2585,6 @@
     "description": "Use the `mongodb_conf` Chef InSpec audit resource to test the contents of the configuration file for MongoDB, typically located at `/etc/mongod.conf` or `C:\\Program Files\\MongoDB\\Server\\<version>\\bin\\mongod.cfg`, depending on the platform.",
     "scope": "source.ruby.chef_inspec"
   },
-  "mongodb_session": {
-    "prefix": "mongodb_session",
-    "body": "describe mongodb_session(user: \"username\", password: \"password\", database: \"test\").query(key: value) do\n    its(\"params\") { should match(/expected-result/) }\n  end",
-    "description": "Use the `mongodb_session` Chef InSpec audit resource to run MongoDB command against a MongoDB Database.",
-    "scope": "source.ruby.chef_inspec"
-  },
   "mount": {
     "prefix": "mount",
     "body": "describe mount('path') do\n\tit { should MATCHER 'value' }\nend",
@@ -2643,18 +2637,6 @@
     "prefix": "oneget",
     "body": "describe oneget('name') do\n\tit { should be_installed }\nend",
     "description": "Use the `oneget` Chef InSpec audit resource to test if the named package and/or package version is installed on the system. This resource uses Oneget, which is `part of the Windows Management Framework 5.0 and Windows 10 <https://github.com/OneGet/oneget>`\\_\\_. This resource uses the `Get-Package` cmdlet to return all of the package names in the Oneget repository.",
-    "scope": "source.ruby.chef_inspec"
-  },
-  "opa_api": {
-    "prefix": "opa_api",
-    "body": "describe opa_api(url: \"localhost:8181/v1/data/example/violation\", data: \"input.json\") do\n\tits([\"result\"]) { should eq 'value' }\nend",
-    "description": "Use the `opa_api` Chef InSpec audit resource to query Open Policy Agent (OPA) using the OPA URL and data.",
-    "scope": "source.ruby.chef_inspec"
-  },
-  "opa_cli": {
-    "prefix": "opa_cli",
-    "body": "describe opa_cli(policy: \"example.rego\", data: \"input.json\", query: \"data.example.allow\") do\n\tits([\"result\"]) { should eq \"value\" }\nend",
-    "description": "Use the `opa_cli` Chef InSpec audit resource to query Open Policy Agent (OPA) using an OPA policy file, a data file, and a query.",
     "scope": "source.ruby.chef_inspec"
   },
   "oracledb_session": {


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Updates the default `rubocopPath` that the extension uses to use the `bin/cookstyle` version rather than `embedded/bin/cookstyle` version as the former is more appropriate.  This will help out for systems which do not have `cookstyle` in sym-linked in the `$PATH` and the extension needs to fall-back to a literal location.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#97

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
