### PR TITLE
Upgrade dependencies to remove deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chef",
   "description": "Official Chef Infra extension for VSCode with code linting support and snippets.",
-  "version": "2.2.10",
+  "version": "2.2.11",
   "publisher": "chef-software",
   "icon": "images/chef-logo.png",
   "displayName": "Chef Infra Extension for Visual Studio Code",
@@ -15,7 +15,7 @@
     "url": "https://github.com/chef/vscode-chef/issues"
   },
   "engines": {
-    "vscode": "^1.1.14"
+    "vscode": "^1.83.0"
   },
   "keywords": [
     "chef",
@@ -35,17 +35,16 @@
   ],
   "main": "./out/extension",
   "devDependencies": {
-    "@types/node": "^18.0.0",
-    "fs": "0.0.1-security",
+    "@types/node": "^20.8.5",
+    "@types/vscode": "^1.83.0",
     "path": "0.12.7",
     "tslint": "6.1.3",
-    "typescript": "4.7.4",
-    "vsce": "^2.6.7",
-    "vscode": "^1.1.14"
+    "typescript": "5.2.2",
+    "@vscode/vsce": "^2.21.1",
+    "@vscode/test-electron": "^2.3.5"
   },
   "extensionDependencies": [
-    "rebornix.ruby",
-    "wingrunr21.vscode-ruby",
+    "Shopify.ruby-lsp",
     "redhat.vscode-yaml"
   ],
   "categories": [
@@ -245,6 +244,6 @@
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "package": "vsce package --out vscode-chef.vsix"
   }
 }


### PR DESCRIPTION
- Use @type/vscode and @vscode/test-electron instead of vscode
- Remove fs unused dependency
- Upgrade @types/node


## Description
All deprecation and security warnings are solved

Add a new rule to create local vsix package

## Related Issue
[Github issue #242](https://github.com/chef/vscode-chef/issues/242)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
