### PR TITLE
CHEF-33964 & CHEF-33965 & CHEF-33975: Cookstyle version enforcement and customization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,60 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 * Enabled by default (disable by adding ```{ "rubocop.enable": false }``` in user/workspace settings) and activated when the first Ruby file is loaded.
 * The entire repo will be linted when files are saved, unless there are more than 400 `*.rb` files in the workspace, in which case only open files will be linted. Adjust this threshold using the ```{ "rubocop.fileCountThreshold": 400 }``` setting in user/workspace settings.
 * You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Pallette.
-* If you have [Chef Workstation](https://downloads.chef.io/chef-workstation) installed, linting should "just work" on Windows, macOS, and Linux. [Cookstyle](https://github.com/chef/cookstyle) will be used by default.
-* If you do not have Chef Workstation but do have Rubocop installed, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\rubocop.bat"}``` in user/workspace settings).
-* To override the config file used by Rubocop/Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings.
+* **Requirements**: This extension requires [Chef Workstation](https://downloads.chef.io/chef-workstation) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. The latest Chef Workstation (26.1.0) includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
+* If Chef Workstation is not installed in the default location, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\cookstyle.bat"}``` in user/workspace settings).
+* To override the config file used by Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings. See [Cookstyle configuration](https://docs.chef.io/workstation/cookstyle/) for more details.
+
+**Note**: While the configuration uses the `rubocop.*` namespace for historical reasons, this extension uses Cookstyle (Chef's customized RuboCop) for linting, not standard RuboCop.
+
+#### Installing/Upgrading Cookstyle
+
+**Option 1: Install Chef Workstation (Recommended)**
+- Download from: https://downloads.chef.io/chef-workstation
+- Latest version (26.1.0) includes Cookstyle 8.7.6 and all Chef tools
+- Works on Windows, macOS, and Linux
+
+**Option 2: Install Cookstyle gem directly**
+```bash
+gem install cookstyle  # Installs latest version
+```
+
+**Option 3: Use with existing Ruby LSP**
+This extension works with the [Shopify Ruby LSP extension](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp). Configure Ruby LSP to use Cookstyle:
+```json
+{
+  "rubyLsp.linters": ["cookstyle"],
+  "rubyLsp.formatter": "cookstyle"
+}
+```
+
+### Customizing Cookstyle Behavior
+
+Cookstyle (RuboCop) behavior can be customized by creating a `.rubocop.yml` file in your workspace root. This allows you to override default formatting and linting rules.
+
+**Example:** Customize array formatting
+```yaml
+# .rubocop.yml in your workspace root
+Style/WordArray:
+  EnforcedStyle: brackets  # Keep ["a", "b"] instead of %w[a b]
+
+Style/SymbolArray:
+  EnforcedStyle: brackets  # Keep [:a, :b] instead of %i[a b]
+```
+
+You can also specify a custom config file path in VS Code settings:
+```json
+{
+  "rubocop.configFile": "path/to/your/config.yml"
+}
+```
+
+See the [Cookstyle documentation](https://docs.chef.io/workstation/cookstyle/) for a complete list of available rules and configuration options.
+
+#### Troubleshooting
+
+**Issue**: Cookstyle version warning on startup  
+**Solution**: Update Chef Workstation to version 26.1.0+ which includes Cookstyle 8.7.6, or install the latest Cookstyle gem directly (`gem install cookstyle`)
 
 ### Snippet support (with tabbing) for all Chef Infra built-in Resources
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 
 * Enabled by default (disable by adding ```{ "rubocop.enable": false }``` in user/workspace settings) and activated when the first Ruby file is loaded.
 * The entire repo will be linted when files are saved, unless there are more than 400 `*.rb` files in the workspace, in which case only open files will be linted. Adjust this threshold using the ```{ "rubocop.fileCountThreshold": 400 }``` setting in user/workspace settings.
-* You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Pallette.
+* You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Palette.
 * **Requirements**: This extension requires [Chef Workstation](https://downloads.chef.io/chef-workstation) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. For example, Chef Workstation 26.1.0 includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
 * If Chef Workstation is not installed in the default location, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\cookstyle.bat"}``` in user/workspace settings.
 * To override the config file used by Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings. See [Cookstyle configuration](https://docs.chef.io/workstation/cookstyle/) for more details.
@@ -34,6 +34,14 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 ```bash
 gem install cookstyle  # Installs latest version
 ```
+
+**Note:** If using the gem-installed Cookstyle, you'll need to configure the path in VS Code settings:
+```json
+{
+  "rubocop.path": "/path/to/cookstyle"
+}
+```
+Or ensure `cookstyle` is available in your PATH.
 
 **Option 3: Use with existing Ruby LSP**
 This extension works with the [Shopify Ruby LSP extension](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp). Configure Ruby LSP to use Cookstyle:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 * Enabled by default (disable by adding ```{ "rubocop.enable": false }``` in user/workspace settings) and activated when the first Ruby file is loaded.
 * The entire repo will be linted when files are saved, unless there are more than 400 `*.rb` files in the workspace, in which case only open files will be linted. Adjust this threshold using the ```{ "rubocop.fileCountThreshold": 400 }``` setting in user/workspace settings.
 * You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Pallette.
-* **Requirements**: This extension requires [Chef Workstation](https://downloads.chef.io/chef-workstation) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. The latest Chef Workstation (26.1.0) includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
-* If Chef Workstation is not installed in the default location, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\cookstyle.bat"}``` in user/workspace settings).
+* **Requirements**: This extension requires [Chef Workstation](https://downloads.chef.io/chef-workstation) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. For example, Chef Workstation 26.1.0 includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
+* If Chef Workstation is not installed in the default location, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\cookstyle.bat"}``` in user/workspace settings.
 * To override the config file used by Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings. See [Cookstyle configuration](https://docs.chef.io/workstation/cookstyle/) for more details.
 
 **Note**: While the configuration uses the `rubocop.*` namespace for historical reasons, this extension uses Cookstyle (Chef's customized RuboCop) for linting, not standard RuboCop.
@@ -27,7 +27,7 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 
 **Option 1: Install Chef Workstation (Recommended)**
 - Download from: https://downloads.chef.io/chef-workstation
-- Latest version (26.1.0) includes Cookstyle 8.7.6 and all Chef tools
+- For example, version 26.1.0 includes Cookstyle 8.7.6 and all Chef tools
 - Works on Windows, macOS, and Linux
 
 **Option 2: Install Cookstyle gem directly**

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 * Enabled by default (disable by adding ```{ "rubocop.enable": false }``` in user/workspace settings) and activated when the first Ruby file is loaded.
 * The entire repo will be linted when files are saved, unless there are more than 400 `*.rb` files in the workspace, in which case only open files will be linted. Adjust this threshold using the ```{ "rubocop.fileCountThreshold": 400 }``` setting in user/workspace settings.
 * You may lint the entire workspace, even if it is larger than the above threshold, using the `Chef: Validate Entire Workspace` command from the Command Palette.
-* **Requirements**: This extension requires [Chef Workstation](https://downloads.chef.io/chef-workstation) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. For example, Chef Workstation 26.1.0 includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
+* **Requirements**: This extension requires [Chef Workstation](https://docs.chef.io/workstation/install/) installed with [Cookstyle](https://github.com/chef/cookstyle) **8.6.10 or later**. For example, Chef Workstation 26.1.0 includes Cookstyle 8.7.6. Linting should "just work" on Windows, macOS, and Linux.
 * If Chef Workstation is not installed in the default location, you can set the executable path by setting ```{ "rubocop.path": "c:\\path\\to\\cookstyle.bat"}``` in user/workspace settings.
 * To override the config file used by Cookstyle, use the ```{ "rubocop.configFile": "path/to/config.yml" }``` in user/workspace settings. See [Cookstyle configuration](https://docs.chef.io/workstation/cookstyle/) for more details.
 
@@ -26,7 +26,7 @@ The Progress Chef Infra Extension for Visual Studio Code offers rich language su
 #### Installing/Upgrading Cookstyle
 
 **Option 1: Install Chef Workstation (Recommended)**
-- Download from: https://downloads.chef.io/chef-workstation
+- Download from Progress Customer Portal or see [installation instructions](https://docs.chef.io/workstation/install/)
 - For example, version 26.1.0 includes Cookstyle 8.7.6 and all Chef tools
 - Works on Windows, macOS, and Linux
 

--- a/extension.ts
+++ b/extension.ts
@@ -103,7 +103,7 @@ function checkCookstyleVersion(): void {
 	} catch (err) {
 		console.log("Could not check Cookstyle version:", err);
 		vscode.window.showWarningMessage(
-			`Chef extension could not detect Cookstyle. Install the latest Chef Workstation for linting features.`,
+			`Chef extension could not detect Cookstyle at: ${rubocopPath}. Verify the path in rubocop.path setting or install Chef Workstation.`,
 			"Download Chef Workstation"
 		).then(selection => {
 			if (selection === "Download Chef Workstation") {

--- a/extension.ts
+++ b/extension.ts
@@ -112,7 +112,7 @@ function checkCookstyleVersion(): void {
 			"Download Chef Workstation"
 		).then(selection => {
 			if (selection === "Download Chef Workstation") {
-				vscode.env.openExternal(vscode.Uri.parse("https://downloads.chef.io/chef-workstation"));
+				vscode.env.openExternal(vscode.Uri.parse("https://docs.chef.io/workstation/install/"));
 			}
 		});
 	}

--- a/extension.ts
+++ b/extension.ts
@@ -10,6 +10,8 @@ let rubocopPath: string;
 let rubocopConfigFile: string;
 let cookbookPaths: Array<string> = [];
 let fileCount: number;
+let cookstyleVersionChecked: boolean = false;
+const MINIMUM_COOKSTYLE_VERSION = "8.6.10";
 
 export function activate(context: vscode.ExtensionContext): void {
 	diagnosticCollectionRubocop = vscode.languages.createDiagnosticCollection("rubocop");
@@ -34,6 +36,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	}
 
 	if (vscode.workspace.getConfiguration("rubocop").enable) {
+		checkCookstyleVersion();
 		updateRubyFileCountAndValidate(true);
 		context.subscriptions.push(startLintingOnSaveWatcher());
 		context.subscriptions.push(startLintingOnConfigurationChangeWatcher());
@@ -46,6 +49,64 @@ export function activate(context: vscode.ExtensionContext): void {
 		validateEntireWorkspace();
   };
   context.subscriptions.push(vscode.commands.registerCommand(command, commandHandler));
+}
+
+function checkCookstyleVersion(): void {
+	if (cookstyleVersionChecked) {
+		return;
+	}
+	
+	try {
+		let spawn = require("child_process").spawnSync;
+		let result = spawn(rubocopPath, ["--version"], { encoding: "utf-8" });
+		
+		if (result.status === 0 && result.stdout) {
+			let versionMatch = result.stdout.match(/(\d+\.\d+\.\d+)/);
+			if (versionMatch) {
+				let version = versionMatch[1];
+				console.log(`Detected Cookstyle version: ${version}`);
+				
+				// Parse version components
+				let parts = version.split('.').map(Number);
+				let minParts = MINIMUM_COOKSTYLE_VERSION.split('.').map(Number);
+				
+				// Check if version is below minimum
+				let isOldVersion = false;
+				for (let i = 0; i < 3; i++) {
+					if (parts[i] < minParts[i]) {
+						isOldVersion = true;
+						break;
+					} else if (parts[i] > minParts[i]) {
+						break;
+					}
+				}
+				
+				if (isOldVersion) {
+					vscode.window.showWarningMessage(
+						`Chef extension detected Cookstyle ${version}. Version ${MINIMUM_COOKSTYLE_VERSION}+ is required. Please upgrade to the latest Chef Workstation for best results.`,
+						"Upgrade Instructions"
+					).then(selection => {
+						if (selection === "Upgrade Instructions") {
+							vscode.env.openExternal(vscode.Uri.parse("https://docs.chef.io/workstation/install/"));
+						}
+					});
+				} else {
+					console.log(`Cookstyle version ${version} is compatible (minimum: ${MINIMUM_COOKSTYLE_VERSION})`);
+				}
+			}
+		}
+		cookstyleVersionChecked = true;
+	} catch (err) {
+		console.log("Could not check Cookstyle version:", err);
+		vscode.window.showWarningMessage(
+			`Chef extension could not detect Cookstyle. Install the latest Chef Workstation for linting features.`,
+			"Download Chef Workstation"
+		).then(selection => {
+			if (selection === "Download Chef Workstation") {
+				vscode.env.openExternal(vscode.Uri.parse("https://downloads.chef.io/chef-workstation"));
+			}
+		});
+	}
 }
 
 function convertSeverity(severity: string): vscode.DiagnosticSeverity {

--- a/extension.ts
+++ b/extension.ts
@@ -56,9 +56,14 @@ function checkCookstyleVersion(): void {
 		return;
 	}
 	
+	// Avoid executing workspace-provided binaries in untrusted workspaces
+	if (!vscode.workspace.isTrusted) {
+		return;
+	}
+	
 	try {
 		let spawn = require("child_process").spawnSync;
-		let result = spawn(rubocopPath, ["--version"], { encoding: "utf-8" });
+		let result = spawn(rubocopPath, ["--version"], { encoding: "utf-8", timeout: 5000, windowsHide: true });
 		
 		if (result.error || result.status !== 0) {
 			throw (result.error ?? new Error(`Cookstyle --version failed with status ${result.status}`));

--- a/extension.ts
+++ b/extension.ts
@@ -60,7 +60,11 @@ function checkCookstyleVersion(): void {
 		let spawn = require("child_process").spawnSync;
 		let result = spawn(rubocopPath, ["--version"], { encoding: "utf-8" });
 		
-		if (result.status === 0 && result.stdout) {
+		if (result.error || result.status !== 0) {
+			throw (result.error ?? new Error(`Cookstyle --version failed with status ${result.status}`));
+		}
+		
+		if (result.stdout) {
 			let versionMatch = result.stdout.match(/(\d+\.\d+\.\d+)/);
 			if (versionMatch) {
 				let version = versionMatch[1];


### PR DESCRIPTION
## Description

This PR combines CHEF-33964 and CHEF-33965 to address the VSCode vs CLI linting conflicts issue.

### Problem

The VSCode extension was giving different linting suggestions than command-line Cookstyle, particularly around array formatting (`["a", "b"]` vs `%w[a b]`). This was caused by shipping an outdated Cookstyle version (< 8.6.10 with RuboCop 1.25) while users' CLI had newer versions.

### Solution

**1. Enforce Minimum Cookstyle Version (CHEF-33964)**
- Added version check requiring Cookstyle 8.6.10 or later
- Shows warning message with upgrade instructions if outdated version detected
- Ensures VSCode and CLI use the same modern RuboCop version for consistent behavior

**2. Document Customization Options (CHEF-33965)**
- Added README documentation for customizing Cookstyle/RuboCop behavior
- Documented two methods:
  - Creating `.rubocop.yml` in workspace root (auto-discovered)
  - Using `rubocop.configFile` VSCode setting for custom config path
- Included examples for preventing %-escaped literals for users who prefer bracket-style arrays

### Testing

✅ Verified both customization methods work correctly with Cookstyle 8.6.10:
- Workspace `.rubocop.yml` is automatically discovered by Cookstyle
- `--config` flag properly applies custom configuration files
- Both VSCode and CLI show identical linting behavior

### Changes

- `extension.ts`: Added `checkCookstyleVersion()` function with minimum version enforcement
- `README.md`: Added "Customizing Cookstyle Behavior" section with examples

### Fixes

- CHEF-33964: Upgrade Cookstyle to Latest Version
- CHEF-33965: Resolve RuboCop–Cookstyle Conflicts (%-escaped literals)
-  EPIC - https://progresssoftware.atlassian.net/browse/CHEF-33906

---

**Note:** This PR replaces #271 and #272 with a cleaner commit history.